### PR TITLE
Remove workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,13 +5,15 @@ jobs:
     runs-on: ubuntu-latest
     name: do-while-not-queued
     steps:
-      - name: Run v1
-        uses: boxofyellow/do-while-not-queued@v1.0.4-beta
-        with:
-          command-line: 'echo'
-          args: 'hello-world'
-          workflow: ${{ github.WORKFLOW }}
-          max-runs: 3
+      # it looks like after I changed name of the main branch it broke our old releases
+      #
+      #- name: Run v1
+      #  uses: boxofyellow/do-while-not-queued@v1.0.4-beta
+      #  with:
+      #    command-line: 'echo'
+      #    args: 'hello-world'
+      #    workflow: ${{ github.WORKFLOW }}
+      #    max-runs: 3
 
       # To use this repository's private action, you must check out the repository
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,15 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     name: do-while-not-queued
     steps:
-      # it looks like after I changed name of the main branch it broke our old releases
-      #
-      #- name: Run v1
-      #  uses: boxofyellow/do-while-not-queued@v1.0.4-beta
-      #  with:
-      #    command-line: 'echo'
-      #    args: 'hello-world'
-      #    workflow: ${{ github.WORKFLOW }}
-      #    max-runs: 3
+      - name: Run v1
+        uses: boxofyellow/do-while-not-queued@v1.0.4-beta
+        with:
+          command-line: 'echo'
+          args: 'hello-world'
+          workflow: ${{ github.WORKFLOW }}
+          max-runs: 3
 
       # To use this repository's private action, you must check out the repository
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,4 @@ jobs:
           max-Runs: 7
           max-time-seconds: 10
           detail-level: 2
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,7 @@ jobs:
           args: 'hello-world'
           workflow: ${{ github.WORKFLOW }}
           max-runs: 3
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       # To use this repository's private action, you must check out the repository
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,4 +25,3 @@ jobs:
           max-Runs: 7
           max-time-seconds: 10
           detail-level: 2
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
           args: 'hello-world'
           workflow: ${{ github.WORKFLOW }}
           max-runs: 3
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # To use this repository's private action, you must check out the repository
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ while(true)
 
 A few things to note:
 1. You can use this to create runs that go for a long time, and inturn consume a lot of your compute resources, so consider using this with Self-Hosted runners
-1. To perform various operations (like check if a new instance of this workflow has been queued) requires a valid token.  The one that is provided when the job starts is only good for 1 hour.  So keep that in mind when selecting max-time-seconds.  To work around this you can prevision your own PAT, and add it as a secret and provide that.
-1. While on the topic of max-time-seconds, no timeout is imposed on your command, this only controls how long the action will look for queued items, you need to ensure your command will complete in a reasonable amount of time.
+1. No timeout is imposed on your command, max-time-seconds only controls how long the action will look for queued items, you need to ensure your command will complete in a reasonable amount of time.
 1. Your command will have access to all Environment variables that are available to actions by default, plus any that add to `env:` 
 
 # Example Usage
@@ -57,6 +56,4 @@ with:
     max-runs: 7
     # If it runs for more then 10 second, stop checking for new instances and exit
     max-time-seconds: 10
-    # Use the provided git hub variable
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A few things to note:
 1. You can use this to create runs that go for a long time, and inturn consume a lot of your compute resources, so consider using this with Self-Hosted runners
 1. No timeout is imposed on your command, max-time-seconds only controls how long the action will look for queued items, you need to ensure your command will complete in a reasonable amount of time.
 1. Your command will have access to all Environment variables that are available to actions by default, plus any that add to `env:` 
+1. To perform various operations (like check if a new instance of this workflow has been queued) requires a valid token.
 
 # Example Usage
 

--- a/README.md
+++ b/README.md
@@ -57,4 +57,6 @@ with:
     max-runs: 7
     # If it runs for more then 10 second, stop checking for new instances and exit
     max-time-seconds: 10
+    # Use the provided git hub variable
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,7 @@ inputs:
   max-time-seconds:
     description: 'The max number of second to keep checking, set < 1 to just keep going'
     required: true
-    default: "2700" # 45 min, since out token is only good for 1 hour.  This buys us some wiggle room
-  GITHUB_TOKEN: 
-    description: 'The Token that has read access to Actions REST API.  And should be set as GITHUB_TOKEN: dollar-dollar{{ secrets.GITHUB_TOKEN }}'
-    required: true
+    default: "3600"  # 1 hour
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
     description: 'The max number of second to keep checking, set < 1 to just keep going'
     required: true
     default: "3600"  # 1 hour
+  GITHUB_TOKEN: 
+    description: 'The Token that has read access to Actions REST API.  And should be set as GITHUB_TOKEN: dollar-dollar{{ secrets.GITHUB_TOKEN }}'
+    required: true
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
It looks like our workaround for the 1-hour github provided token is not needed.
While the need to supply your PAT, you sill need to provide _a_ token
Fixes #5