### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,6 +1,6 @@
 name: Keep the versions up-to-date
 permissions:
-  contents: write
+  contents: write # we need write here, not for `Update main.yml to match new tags` (as that uses its own token), in stead for `Actions-R-Us/actions-tagger`
 
 on:
   release:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,4 +1,6 @@
 name: Keep the versions up-to-date
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/boxofyellow/do-while-not-queued/security/code-scanning/1](https://github.com/boxofyellow/do-while-not-queued/security/code-scanning/1)

To fix the issue, add an explicit `permissions:` block to the workflow, specifying the minimal set required.  
Since the workflow pushes commits to workflows (`contents: write`) and may interact with releases (`pull-requests: write` or `contents: write`), set the following in the root of the workflow (just after the `name:` block):

- If only reading repo contents is required, use `contents: read` as the minimal starting point.
- If writing (pushing commits to the repo/branch) is needed, use `contents: write`.

In this workflow, the job pushes to `main`, so it requires at least `contents: write`.  
Add the following block to the top (after the `name:`):

```yaml
permissions:
  contents: write
```

No other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
